### PR TITLE
fix: set HTTPS as protocol default

### DIFF
--- a/src/endpoint-health-check.ts
+++ b/src/endpoint-health-check.ts
@@ -105,7 +105,8 @@ export class EndpointHealthCheck extends HealthCheckBase {
   constructor(scope: Construct, id: string, props: EndpointHealthCheckProps) {
     super(scope, id);
 
-    const type = this.healthCheckType(props.protocol, props.searchString);
+    const protocol = props.protocol || Protocol.HTTPS;
+    const type = this.healthCheckType(protocol, props.searchString);
     const port = this.defaultPort(props.port, type);
     const enableSni = this.enableSniForHttps(type, props.enableSni);
 

--- a/test/endpoint-health-check.test.ts
+++ b/test/endpoint-health-check.test.ts
@@ -121,4 +121,28 @@ describe("EndpointHealthCheck", () => {
 
     expect(capture.asObject()).not.toHaveProperty("InsufficientDataHealthStatus");
   });
+
+  it("Should be of type HTTPS_STR_MATCH if a searchString is specified", () => {
+    // Given
+    const stack = new Stack();
+    new EndpointHealthCheck(stack, "HealthCheck", {
+      domainName: "pepperize.com",
+      searchString: "UP",
+    });
+
+    // When
+    const template = Template.fromStack(stack);
+    const annotations = Annotations.fromStack(stack);
+
+    // Then
+    template.hasResourceProperties("AWS::Route53::HealthCheck", {
+      HealthCheckConfig: {
+        FullyQualifiedDomainName: "pepperize.com",
+        Port: 443,
+        Type: "HTTPS_STR_MATCH",
+        EnableSNI: true,
+      },
+    });
+    annotations.hasNoError("/Default/HealthCheck", "*");
+  });
 });


### PR DESCRIPTION
Fixes #379

This PR sets `protocol` to `HTTPS` if not specified. This leads to the correct determination of the heath check type (`HTTPS_STR_MATCH`) when calling `healthCheckType`.