### PR TITLE
fix: remove TagManager-generated tags to prevent Route53 validation e…

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2025 Pepperize UG (haftungsbeschränkt)
+Copyright (c) 2026 Pepperize UG (haftungsbeschränkt)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/alarm-health-check.ts
+++ b/src/alarm-health-check.ts
@@ -54,7 +54,7 @@ export class AlarmHealthCheck extends HealthCheckBase {
         insufficientDataHealthStatus: insufficientDataHealthStatus,
         type: HealthCheckType.CLOUDWATCH_METRIC,
       },
-      healthCheckTags: this.getSafeRenderedTags(),
+      healthCheckTags: this.resolveSafeTags(),
     });
 
     this.healthCheckId = resource.attrHealthCheckId;

--- a/src/alarm-health-check.ts
+++ b/src/alarm-health-check.ts
@@ -54,7 +54,7 @@ export class AlarmHealthCheck extends HealthCheckBase {
         insufficientDataHealthStatus: insufficientDataHealthStatus,
         type: HealthCheckType.CLOUDWATCH_METRIC,
       },
-      healthCheckTags: [],
+      healthCheckTags: this.getSafeRenderedTags(),
     });
 
     this.healthCheckId = resource.attrHealthCheckId;

--- a/src/alarm-health-check.ts
+++ b/src/alarm-health-check.ts
@@ -54,7 +54,7 @@ export class AlarmHealthCheck extends HealthCheckBase {
         insufficientDataHealthStatus: insufficientDataHealthStatus,
         type: HealthCheckType.CLOUDWATCH_METRIC,
       },
-      healthCheckTags: this.tags.renderedTags,
+      healthCheckTags: [],
     });
 
     this.healthCheckId = resource.attrHealthCheckId;

--- a/src/calculated-health-check.ts
+++ b/src/calculated-health-check.ts
@@ -58,7 +58,7 @@ export class CalculatedHealthCheck extends HealthCheckBase {
         healthThreshold: props.healthThreshold,
         type: HealthCheckType.CALCULATED,
       },
-      healthCheckTags: [],
+      healthCheckTags: this.getSafeRenderedTags(),
     });
 
     this.healthCheckId = resource.attrHealthCheckId;

--- a/src/calculated-health-check.ts
+++ b/src/calculated-health-check.ts
@@ -58,7 +58,7 @@ export class CalculatedHealthCheck extends HealthCheckBase {
         healthThreshold: props.healthThreshold,
         type: HealthCheckType.CALCULATED,
       },
-      healthCheckTags: this.tags.renderedTags,
+      healthCheckTags: [],
     });
 
     this.healthCheckId = resource.attrHealthCheckId;

--- a/src/calculated-health-check.ts
+++ b/src/calculated-health-check.ts
@@ -58,7 +58,7 @@ export class CalculatedHealthCheck extends HealthCheckBase {
         healthThreshold: props.healthThreshold,
         type: HealthCheckType.CALCULATED,
       },
-      healthCheckTags: this.getSafeRenderedTags(),
+      healthCheckTags: this.resolveSafeTags(),
     });
 
     this.healthCheckId = resource.attrHealthCheckId;

--- a/src/endpoint-health-check.ts
+++ b/src/endpoint-health-check.ts
@@ -158,7 +158,7 @@ export class EndpointHealthCheck extends HealthCheckBase {
         measureLatency: props.latencyGraphs,
         regions: props.regions,
       },
-      healthCheckTags: [],
+      healthCheckTags: this.getSafeRenderedTags(),
     });
 
     this.healthCheckId = resource.attrHealthCheckId;

--- a/src/endpoint-health-check.ts
+++ b/src/endpoint-health-check.ts
@@ -158,7 +158,7 @@ export class EndpointHealthCheck extends HealthCheckBase {
         measureLatency: props.latencyGraphs,
         regions: props.regions,
       },
-      healthCheckTags: this.getSafeRenderedTags(),
+      healthCheckTags: this.resolveSafeTags(),
     });
 
     this.healthCheckId = resource.attrHealthCheckId;

--- a/src/endpoint-health-check.ts
+++ b/src/endpoint-health-check.ts
@@ -158,7 +158,7 @@ export class EndpointHealthCheck extends HealthCheckBase {
         measureLatency: props.latencyGraphs,
         regions: props.regions,
       },
-      healthCheckTags: this.tags.renderedTags,
+      healthCheckTags: [],
     });
 
     this.healthCheckId = resource.attrHealthCheckId;

--- a/src/health-check.ts
+++ b/src/health-check.ts
@@ -85,7 +85,7 @@ export abstract class HealthCheckBase extends Resource implements IHealthCheck, 
 
   readonly tags = new TagManager(TagType.STANDARD, "AWS::Route53::HealthCheck");
 
-  protected getSafeRenderedTags(): route53.CfnHealthCheck.HealthCheckTagProperty[] | IResolvable {
+  protected resolveSafeTags(): route53.CfnHealthCheck.HealthCheckTagProperty[] | IResolvable {
     return Lazy.any({
       produce: () => {
         const raw = this.tags.renderedTags;
@@ -102,9 +102,7 @@ export abstract class HealthCheckBase extends Resource implements IHealthCheck, 
           return allowed.test(v) && !v.includes("${") && !v.includes("}") && !v.includes("$");
         }
 
-        return arr
-          .filter((t) => typeof t.key === "string" && isSafeString(t.value))
-          .map((t) => ({ key: t.key!, value: t.value! }));
+        return arr.filter((t) => isSafeString(t.value)).map((t) => ({ key: t.key!, value: t.value! }));
       },
     });
   }

--- a/src/health-check.ts
+++ b/src/health-check.ts
@@ -1,4 +1,4 @@
-import { ITaggable, Resource, TagManager, TagType } from "aws-cdk-lib";
+import { IResolvable, ITaggable, Lazy, Resource, TagManager, TagType, Token } from "aws-cdk-lib";
 import * as cloudwatch from "aws-cdk-lib/aws-cloudwatch";
 import * as route53 from "aws-cdk-lib/aws-route53";
 import { RecordSet } from "aws-cdk-lib/aws-route53";
@@ -84,6 +84,30 @@ export abstract class HealthCheckBase extends Resource implements IHealthCheck, 
   public abstract readonly healthCheckId: string;
 
   readonly tags = new TagManager(TagType.STANDARD, "AWS::Route53::HealthCheck");
+
+  protected getSafeRenderedTags(): route53.CfnHealthCheck.HealthCheckTagProperty[] | IResolvable {
+    return Lazy.any({
+      produce: () => {
+        const raw = this.tags.renderedTags;
+
+        if (Token.isUnresolved(raw)) {
+          return raw;
+        }
+
+        const arr = raw as unknown as route53.CfnHealthCheck.HealthCheckTagProperty[];
+
+        function isSafeString(v: unknown) {
+          if (typeof v !== "string") return false;
+          const allowed = /^[a-zA-Z0-9 _.:\/=+\-@]+$/;
+          return allowed.test(v) && !v.includes("${") && !v.includes("}") && !v.includes("$");
+        }
+
+        return arr
+          .filter((t) => typeof t.key === "string" && isSafeString(t.value))
+          .map((t) => ({ key: t.key!, value: t.value! }));
+      },
+    });
+  }
 
   failover(recordSet: RecordSet, evaluateTargetHealth?: boolean, failover?: Failover) {
     const resource = recordSet.node.defaultChild;


### PR DESCRIPTION
- Summary of the Issue and Fix:

In CDK v2, this.tags.renderedTags no longer returns an array during construct initialization. Instead, it often returns an IResolvable (a lazy token).
Because of this, the previous code attempted to treat a token as an iterable array, which caused runtime errors such as:
**_TypeError: p.healthCheckTags is not iterable_**

Additionally, filtering tags at construct time always resulted in an empty array because the real tag values are only available after the token is resolved.

- Solution

Wrap tag processing in Lazy.any({ produce: ... }) so the logic runs at token‑resolve time, when tags are finally expanded into a real array.
If renderedTags is still unresolved, return it unchanged and let CDK resolve it later.
Only apply filtering once the token has resolved to a concrete HealthCheckTagProperty[].

- This ensures that:

No “not iterable” errors occur,
Tags are resolved correctly,
The HealthCheck receives the expected Name tag,
Unit tests pass again.